### PR TITLE
feat: Limited the display of the overall leaderboard to the top 5 only

### DIFF
--- a/frontend/src/components/OverallLeaderboard.js
+++ b/frontend/src/components/OverallLeaderboard.js
@@ -79,7 +79,7 @@ setUserScoresArray(sortedUserScoresArray);
                     <tbody>
                     {/* Display the user scores, creating a row for each user */}
                     {userScoresArray.length > 0 ? (
-                        userScoresArray.map((subArray, index) => (
+                        userScoresArray.slice(0,5).map((subArray, index) => (
                             <tr key={index}>
                                 <td>{index + 1}</td> {/* Rank */}
                                 <td>{subArray[0]}</td> {/* Name */}


### PR DESCRIPTION
## Context

<!-- Include contextual info that can't be found in the linked issue. Why are you making this change? -->

Closes #60 

## What Changed?

I limited the size of the leaderboard to only be 5 rows of data.

## How To Review

Start the application including the backend and frontend and look at the homepage to see if the leaderboard displayed contains only 5 rows of user data.

## Testing

I have created additional users to ensure none are added to the leaderboard.

## Risks

NA

## Notes

**If an error occurs on start up saying " Module not found error can't resolve 'mdb-react-ui-kit' " ensure to do npm install in the frontend folder** This is due to the footer commit.
