### PR TITLE
Feat/implement daily leaderboard in games

### DIFF
--- a/Backend/controllers/recordController.js
+++ b/Backend/controllers/recordController.js
@@ -5,7 +5,12 @@ const ChimpTestRecords = require('../models/chimpTestRecordModel');
 const ColourPuzzleRecords = require('../models/colourPuzzleRecordModel');
 const OverallRecords = require('../models/overallScoreRecordModel');
 const { get } = require('mongoose');
-const currentDay = new Date().toISOString().slice(0, 10);
+const startOfDay = new Date().setHours(0,0,0,0)
+
+
+const endOfDay = new Date().setHours(23,59,59,999)
+
+
 // Get all reaction records
 const getAllRecords = async (req, res) => {
     let records;
@@ -43,16 +48,36 @@ const getTopScores = async (req, res) => {
 
         let topScores;
         if(screen=="1"){
-            topScores = await DinoJumpRecords.find({}).sort({ score: -1 }).limit(5);
+            topScores = await DinoJumpRecords.find({
+                createdAt: {
+                  $gte: startOfDay,  // Greater than or equal to the start of the day
+                  $lt: endOfDay      // Less than the end of the day
+                }
+              }).sort({ score: -1 }).limit(5);
         }
         else if(screen=="2"){
-            topScores = await ReactionGameRecords.find({}).sort({ score: 1 }).limit(5);
+            topScores = await ReactionGameRecords.find({
+                createdAt: {
+                  $gte: startOfDay,  // Greater than or equal to the start of the day
+                  $lt: endOfDay      // Less than the end of the day
+                }
+              }).sort({ score: 1 }).limit(5);
         }
         else if(screen=="3"){
-            topScores = await ColourPuzzleRecords.find({}).sort({ score: -1 }).limit(5);
+            topScores = await ColourPuzzleRecords.find({
+                createdAt: {
+                  $gte: startOfDay,  // Greater than or equal to the start of the day
+                  $lt: endOfDay      // Less than the end of the day
+                }
+              }).sort({ score: -1 }).limit(5);
         }
         else if(screen=="4"){
-            topScores = await ChimpTestRecords.find({}).sort({ score: -1 }).limit(5);
+            topScores = await ChimpTestRecords.find({
+                createdAt: {
+                  $gte: startOfDay,  // Greater than or equal to the start of the day
+                  $lt: endOfDay      // Less than the end of the day
+                }
+              }).sort({ score: -1 }).limit(5);
         }
         res.status(200).json(topScores);
     } catch (error) {
@@ -147,7 +172,12 @@ const getUserRank = async (req, res) => {
         
         let rank = 1;
         if (screen=="1"){
-            allRecords = await DinoJumpRecords.find({}).sort({ score: -1 });
+            allRecords = await DinoJumpRecords.find({
+                createdAt: {
+                  $gte: startOfDay,  // Greater than or equal to the start of the day
+                  $lt: endOfDay      // Less than the end of the day
+                }
+              }).sort({ score: -1 });
             for (let i = 0; i < allRecords.length; i++) {
                 if (allRecords[i].score >= score) {
                     rank++;
@@ -157,7 +187,12 @@ const getUserRank = async (req, res) => {
             }
         }
         else if(screen=="2"){
-             allRecords = await ReactionGameRecords.find({}).sort({ score: 1 });
+             allRecords = await ReactionGameRecords.find({
+                createdAt: {
+                  $gte: startOfDay,  // Greater than or equal to the start of the day
+                  $lt: endOfDay      // Less than the end of the day
+                }
+              }).sort({ score: 1 });
              for (let i = 0; i < allRecords.length; i++) {
                 if (allRecords[i].score <= score) {
                     rank++;
@@ -167,7 +202,12 @@ const getUserRank = async (req, res) => {
             }
         }
         else if (screen=="3"){
-            allRecords = await ColourPuzzleRecords.find({}).sort({ score: 1 });
+            allRecords = await ColourPuzzleRecords.find({
+                createdAt: {
+                  $gte: startOfDay,  // Greater than or equal to the start of the day
+                  $lt: endOfDay      // Less than the end of the day
+                }
+              }).sort({ score: 1 });
             for (let i = 0; i < allRecords.length; i++) {
                 if (allRecords[i].score <= score) {
                     rank++;
@@ -177,7 +217,12 @@ const getUserRank = async (req, res) => {
             }}
 
         else if (screen=="4"){
-            allRecords = await ChimpTestRecords.find({}).sort({ score: -1 });
+            allRecords = await ChimpTestRecords.find({
+                createdAt: {
+                  $gte: startOfDay,  // Greater than or equal to the start of the day
+                  $lt: endOfDay      // Less than the end of the day
+                }
+              }).sort({ score: -1 });
             for (let i = 0; i < allRecords.length; i++) {
                 if (allRecords[i].score >= score) {
                     rank++;

--- a/Backend/controllers/recordController.js
+++ b/Backend/controllers/recordController.js
@@ -5,7 +5,7 @@ const ChimpTestRecords = require('../models/chimpTestRecordModel');
 const ColourPuzzleRecords = require('../models/colourPuzzleRecordModel');
 const OverallRecords = require('../models/overallScoreRecordModel');
 const { get } = require('mongoose');
-
+const currentDay = new Date().toISOString().slice(0, 10);
 // Get all reaction records
 const getAllRecords = async (req, res) => {
     let records;
@@ -38,8 +38,9 @@ const getTopScores = async (req, res) => {
         const screen = req.headers['screen'];
         // Access the screen parameter
         
-        const startOfDay = new Date();
-        startOfDay.setHours(0, 0, 0, 0);
+   
+        
+
         let topScores;
         if(screen=="1"){
             topScores = await DinoJumpRecords.find({}).sort({ score: -1 }).limit(5);

--- a/Backend/controllers/recordController.js
+++ b/Backend/controllers/recordController.js
@@ -58,24 +58,24 @@ const getTopScores = async (req, res) => {
         else if(screen=="2"){
             topScores = await ReactionGameRecords.find({
                 createdAt: {
-                  $gte: startOfDay,  // Greater than or equal to the start of the day
-                  $lt: endOfDay      // Less than the end of the day
+                  $gte: startOfDay,  
+                  $lt: endOfDay      
                 }
               }).sort({ score: 1 }).limit(5);
         }
         else if(screen=="3"){
             topScores = await ColourPuzzleRecords.find({
                 createdAt: {
-                  $gte: startOfDay,  // Greater than or equal to the start of the day
-                  $lt: endOfDay      // Less than the end of the day
+                  $gte: startOfDay,  
+                  $lt: endOfDay      
                 }
               }).sort({ score: -1 }).limit(5);
         }
         else if(screen=="4"){
             topScores = await ChimpTestRecords.find({
                 createdAt: {
-                  $gte: startOfDay,  // Greater than or equal to the start of the day
-                  $lt: endOfDay      // Less than the end of the day
+                  $gte: startOfDay,  
+                  $lt: endOfDay      
                 }
               }).sort({ score: -1 }).limit(5);
         }
@@ -174,8 +174,8 @@ const getUserRank = async (req, res) => {
         if (screen=="1"){
             allRecords = await DinoJumpRecords.find({
                 createdAt: {
-                  $gte: startOfDay,  // Greater than or equal to the start of the day
-                  $lt: endOfDay      // Less than the end of the day
+                  $gte: startOfDay,  
+                  $lt: endOfDay      
                 }
               }).sort({ score: -1 });
             for (let i = 0; i < allRecords.length; i++) {
@@ -189,8 +189,8 @@ const getUserRank = async (req, res) => {
         else if(screen=="2"){
              allRecords = await ReactionGameRecords.find({
                 createdAt: {
-                  $gte: startOfDay,  // Greater than or equal to the start of the day
-                  $lt: endOfDay      // Less than the end of the day
+                  $gte: startOfDay,  
+                  $lt: endOfDay      
                 }
               }).sort({ score: 1 });
              for (let i = 0; i < allRecords.length; i++) {
@@ -204,8 +204,8 @@ const getUserRank = async (req, res) => {
         else if (screen=="3"){
             allRecords = await ColourPuzzleRecords.find({
                 createdAt: {
-                  $gte: startOfDay,  // Greater than or equal to the start of the day
-                  $lt: endOfDay      // Less than the end of the day
+                  $gte: startOfDay,  
+                  $lt: endOfDay      
                 }
               }).sort({ score: 1 });
             for (let i = 0; i < allRecords.length; i++) {
@@ -219,8 +219,8 @@ const getUserRank = async (req, res) => {
         else if (screen=="4"){
             allRecords = await ChimpTestRecords.find({
                 createdAt: {
-                  $gte: startOfDay,  // Greater than or equal to the start of the day
-                  $lt: endOfDay      // Less than the end of the day
+                  $gte: startOfDay,  
+                  $lt: endOfDay      
                 }
               }).sort({ score: -1 });
             for (let i = 0; i < allRecords.length; i++) {

--- a/frontend/src/components/OverallLeaderboard.js
+++ b/frontend/src/components/OverallLeaderboard.js
@@ -79,7 +79,7 @@ setUserScoresArray(sortedUserScoresArray);
                     <tbody>
                     {/* Display the user scores, creating a row for each user */}
                     {userScoresArray.length > 0 ? (
-                        userScoresArray.map((subArray, index) => (
+                        userScoresArray.slice(0,5).map((subArray, index) => (
                             <tr key={index}>
                                 <td>{index + 1}</td> {/* Rank */}
                                 <td>{subArray[0]}</td> {/* Name */}


### PR DESCRIPTION
## Context

There was a mismatch between the text "Top 5 scores of the day" and the actual functioanlity which fetched the top 5 scores overall. So I fixed it by filtering the data queried and retreived from the MongoDB Collection

Closes #62 

## What Changed?

I filtered the scores retrieved from the MongoDB Collection so they were in the range of the start of the current day and the end of the current day.

## How To Review

They should view the games in any order, and examine the top 5 score retrieved and displayed. They can also play the game and test how the retreived scores vary. Testing at midnight could be especially useful.

## Testing

I tested it by submitting scores at 12:30 am to test the date querying and it seemed to work.

## Risks

A risk may be if MongoDB does not correctly parse the Date objects as they are in NZDT and MongoDB uses UTC, but it should do it automatically and easily. Another risk may be due to Daylight Savings Time in New Zealand, or other timezone specific issues.

A slight risk, is an error may be shown in the terminal if no scores exist in the last 24 hours, but I have tested it and I dont think one is thrown but there is a possibility. The error won't affect any functionality or the application in any way.

## Notes
This should be approved after the leaderboard size pr.

This **does not** query the values submitted in the last 24 hours, only those submitted in the current day.